### PR TITLE
Fix incomplete oh-my-zsh config

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -198,3 +198,12 @@ fi
 
 # Set name of the theme to load --- if set to "random", it will
 # load a random theme each time oh-my-zsh is loaded, in which case,
+# to know which specific one was loaded, run: echo $RANDOM_THEME
+ZSH_THEME="robbyrussell"
+
+# Which plugins would you like to load?
+# Standard plugins can be found in $ZSH/plugins/
+# Custom plugins may be added to $ZSH_CUSTOM/plugins/
+plugins=(git)
+
+source $ZSH/oh-my-zsh.sh


### PR DESCRIPTION
## Summary
- finish oh-my-zsh configuration in `.zshrc`

## Testing
- `true`
