### PR TITLE
Add ShellCheck workflow and fix warnings

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,19 @@
+name: ShellCheck
+
+on:
+  push:
+    paths:
+      - '**/*.sh'
+  pull_request:
+    paths:
+      - '**/*.sh'
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run ShellCheck
+        run: shellcheck install.sh setup.sh

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -65,13 +65,14 @@ for other_file in .gitconfig .bashrc; do # Add other files here if necessary
 done
 
 # Stow it all
-STOW_PACKAGES="home config ssh" # .config will be treated as 'config' by stow
-print_message "${BLUE}" "🔗" "Stowing packages: $STOW_PACKAGES from $(pwd) into ~"
-stow -v -t ~ $STOW_PACKAGES
+STOW_PACKAGES=(home config ssh) # .config will be treated as 'config' by stow
+print_message "${BLUE}" "🔗" "Stowing packages: ${STOW_PACKAGES[*]} from $(pwd) into ~"
+stow -v -t ~ "${STOW_PACKAGES[@]}"
 
 # Source the new .zshrc if using zsh
 if [ "$SHELL" = "/bin/zsh" ] || [ "$SHELL" = "/usr/bin/zsh" ] || [ "$SHELL" = "/usr/local/bin/zsh" ]; then
   print_message "${BLUE}" "🔄" "Sourcing new .zshrc"
+  # shellcheck disable=SC1090
   source "$HOME/.zshrc" 2>/dev/null || true
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # setup.sh - Initial setup script for a new Mac
 # This script installs essential software and configures the system
+set -euo pipefail
 # IMPORTANT: This script should NOT be run with sudo
 
 # Colors for output
@@ -292,8 +293,8 @@ install_arc_extensions() {
 
   # Install each extension
   for extension in "${extensions[@]}"; do
-    extension_id=$(echo $extension | cut -d' ' -f1)
-    extension_name=$(echo $extension | cut -d' ' -f2-)
+    extension_id=$(echo "$extension" | cut -d' ' -f1)
+    extension_name=$(echo "$extension" | cut -d' ' -f2-)
     install_extension "$extension_id" "$extension_name"
   done
 
@@ -506,4 +507,4 @@ main() {
 }
 
 # Run the main function
-main
+main "$@"


### PR DESCRIPTION
## Summary
- set up CI with ShellCheck
- fix ShellCheck warnings in install.sh and setup.sh

## Testing
- `shellcheck install.sh setup.sh` *(fails: command not found)*
- `sudo apt-get update && sudo apt-get install -y shellcheck` *(fails: network unreachable)*